### PR TITLE
Rahi_CanteenSceneHappened flag fix

### DIFF
--- a/Modules/RahiModule/RahiAvyCanteenScene.gd
+++ b/Modules/RahiModule/RahiAvyCanteenScene.gd
@@ -281,6 +281,7 @@ func _react(_action: String, _args):
 		GM.pc.addPain(-30)
 
 	if(_action == "endthescene"):
+		setModuleFlag("RahiModule", "Rahi_CanteenSceneHappened", true)
 		endScene()
 		return
 	


### PR DESCRIPTION
This scene's activation, as well as conditional Avy dialogue in AvyFirstTimeTalkScene and rahi3PassOutScene, check for the Rahi_CanteenSceneHappened flag, but the flag was never switched on anywhere.

All this time I just assumed that Avy **REALLY** wanted her goddamn money 0_0