### PR TITLE
add NpcCon.NotInStocksOrEquivalent to hypno encounter

### DIFF
--- a/Characters/Dynamic/NpcCon.gd
+++ b/Characters/Dynamic/NpcCon.gd
@@ -24,4 +24,5 @@ enum {
 	HasReachablePenis,
 	HasReachableAnus,
 	IgnoreDisabledEncountersSetting,
+	NotInStocksOrEquivalent,
 }

--- a/Characters/Dynamic/NpcFinder.gd
+++ b/Characters/Dynamic/NpcFinder.gd
@@ -65,6 +65,11 @@ static func npcSatisfiesCondition(character:BaseCharacter, conInfo):
 	elif(conditionID == NpcCon.HasReachableAnus):
 		if(!character.hasReachableAnus()):
 			return false
+	elif(conditionID == NpcCon.NotInStocksOrEquivalent):
+		var characterInventory:Inventory = character.getInventory()
+
+		if( characterInventory.hasItemIDEquipped("StocksStatic") || characterInventory.hasItemIDEquipped("SlutwallStatic") ):
+			return false
 	return true
 
 static func npcCanBeUsedAtAll(character:BaseCharacter, allConditions):

--- a/Modules/HypnokinkModule/Events/HK_HypnoEncounterInmateEvent.gd
+++ b/Modules/HypnokinkModule/Events/HK_HypnoEncounterInmateEvent.gd
@@ -11,7 +11,7 @@ func react(_triggerID, _args):
 	if(_args.size() > 0):
 		encounterLevel = _args[0]
 	
-	var idToUse = grabNpcIDFromPoolOrGenerate(CharacterPool.Inmates, [], InmateGenerator.new(), {NpcGen.Level: encounterLevel})
+	var idToUse = grabNpcIDFromPoolOrGenerate(CharacterPool.Inmates, [[NpcCon.NotInStocksOrEquivalent]], InmateGenerator.new(), {NpcGen.Level: encounterLevel})
 	
 	if(idToUse == null || idToUse == ""):
 		return false


### PR DESCRIPTION
this fixes #154 but.. i don't imagine `grabNpcIDFromPoolOrGenerate` gets used often with an expectation to get someone in stocks/slutwall, so it might make sense to have this condition on by default, perhaps with a way to disable it when you in fact do want critters in stocks/slutwall to sometimes be part of the results

feel free to do it differently, it didn't particularly take me long