### PR TITLE
Add "become" console command + make help reference aware

### DIFF
--- a/UI/DebugUI/ConsoleSingleton.gd
+++ b/UI/DebugUI/ConsoleSingleton.gd
@@ -88,6 +88,7 @@ func getCommandsHelp():
 	var result = ""
 	for command_name in commands:
 		var command = commands[command_name]
-		result += command_name + " - args=" + str(command["params"])+" - " + str(command["description"])+"\n"
+		if(command["object"].get_ref() != null):
+			result += command_name + " - args=" + str(command["params"])+" - " + str(command["description"])+"\n"
 		
 	return result


### PR DESCRIPTION
The "become" command allow the player to become any character id, only swapping body parts, skin, and visible elements.

Does not copy items, inventory, or equipment.