### PR TITLE
pronoun selection tweaks

### DIFF
--- a/Scenes/CharacterCreatorScene.gd
+++ b/Scenes/CharacterCreatorScene.gd
@@ -29,11 +29,12 @@ func _run():
 
 	if(state == "pickpronouns"):
 		say("Pick your character's pronouns. This can be changed at any point")
-		addButton("Same as gender", "Use your gender's pronouns", "setpronouns", [null])
-		addButton("Male", "He/his", "setpronouns", [Gender.Male])
-		addButton("Female", "She/her", "setpronouns", [Gender.Female])
-		addButton("Androgynous", "They/their", "setpronouns", [Gender.Androgynous])
-		addButton("Other", "It/its", "setpronouns", [Gender.Other])
+
+		addButton("Derive from gender", "Automatically adjust pronouns based on gender", "setpronouns", [null])
+		addButton("he/his", "Choose masculine pronouns", "setpronouns", [Gender.Male])
+		addButton("she/her", "Choose feminine pronouns", "setpronouns", [Gender.Female])
+		addButton("they/their", "Choose androgynous or neutral pronouns", "setpronouns", [Gender.Androgynous])
+		addButton("it/its", "Choose neutral pronouns", "setpronouns", [Gender.Other])
 		addButton("back", "Back to picking gender", "pickgender")
 
 	if(state == "pickspecies"):

--- a/Scenes/MeScene.gd
+++ b/Scenes/MeScene.gd
@@ -137,8 +137,9 @@ func _run():
 		addButton("Continue", "Good", "")
 
 	if(state == "pickgender"):
-		say("Pick your character's gender. This will affect the color of your speech and how others treat you. This can be changed at any point")
-		
+		saynn("Pick your character's gender. This will affect the color of your speech and how others treat you.")
+		saynn("Current gender: [color="+GM.pc.getChatColor()+"]"+Gender.genderToString(GM.pc.getGender()).capitalize()+"[/color]")
+
 		addButton("Male", "You're a guy", "setgender", [Gender.Male])
 		addButton("Female", "You're a girl", "setgender", [Gender.Female])
 		addButton("Androgynous", "Somewhere in between", "setgender", [Gender.Androgynous])
@@ -146,13 +147,15 @@ func _run():
 		addButton("back", "Keep your current gender", "")
 
 	if(state == "pickpronouns"):
-		say("Pick your character's pronouns. This can be changed at any point")
-		addButton("Same as gender", "Use your gender's pronouns", "setpronouns", [null])
-		addButton("Male", "He/his", "setpronouns", [Gender.Male])
-		addButton("Female", "She/her", "setpronouns", [Gender.Female])
-		addButton("Androgynous", "They/their", "setpronouns", [Gender.Androgynous])
-		addButton("Other", "It/its", "setpronouns", [Gender.Other])
-		addButton("back", "Keep your pronouns", "")
+		saynn("Pick your character's pronouns.")
+		saynn("Current pronouns: "+GM.pc.heShe()+"/"+GM.pc.hisHer()+(" (derived from gender)" if(GM.pc.pronounsGender == null) else ""))
+
+		addButton("Derive from gender", "Automatically adjust pronouns based on gender", "setpronouns", [null])
+		addButton("he/his", "Choose masculine pronouns", "setpronouns", [Gender.Male])
+		addButton("she/her", "Choose feminine pronouns", "setpronouns", [Gender.Female])
+		addButton("they/their", "Choose androgynous or neutral pronouns", "setpronouns", [Gender.Androgynous])
+		addButton("it/its", "Choose neutral pronouns", "setpronouns", [Gender.Other])
+		addButton("back", "Keep your current pronouns", "")
 	
 	if(state == "wait"):
 		saynn("Choose how long do you want wait.")


### PR DESCRIPTION
when asking player for the character's pronouns, show the pronouns themselves instead of genders

i've tried to adjust the wording to make less assumptions, since genders aren't always associated with specific pronouns, they/their isn't necessarily androgynous, non-gendered creatures aren't always it/its, and auto-selected pronouns are just something we assume/derive when trying to correctly refer to someone

\-

also shows current gender in a pretty color, since there is a button "keep your current gender" but you might forget what it currently is.. or just as a preview for chat color

<img width="704" height="210" alt="Pick your character's gender. This will affect the color of your speech and how others treat you. Current gender: Androgynous, with the word androgynous colored in purple." src="https://github.com/user-attachments/assets/31b8159e-b8b5-4a19-88d7-7f19d5243436" />
