### PR TITLE
group TF pills in sex engine, add similar support for bondage items

### DIFF
--- a/Game/SexEngine/SexActivity/DomBondage.gd
+++ b/Game/SexEngine/SexActivity/DomBondage.gd
@@ -106,8 +106,9 @@ func getStartActions(_sexEngine: SexEngine, _domInfo: SexDomInfo, _subInfo: SexS
 				continue
 			
 			if(_domInfo.getChar().isPlayer()):
+				var itemCategory:Array = getCategory() + item.getSexEngineSubcategory()
 #func addStartAction(_aArgs:Array, _aName:String, _aDesc:String, _aScore:float, _aExtra:Dictionary = {}):
-				addStartAction(["pc", item.uniqueID], item.getVisibleName(), "Restraint level: "+str(restraintData.getLevel()) + "\n" + item.getCombatDescription(), theActivityScore, {A_CATEGORY: (getCategory() if (!countsByItemID.has(item.id) || countsByItemID[item.id] <= 1) else (getCategory() + [str(countsByItemID[item.id])+"x"+item.getVisibleName()]))})
+				addStartAction(["pc", item.uniqueID], item.getVisibleName(), "Restraint level: "+str(restraintData.getLevel()) + "\n" + item.getCombatDescription(), theActivityScore, {A_CATEGORY: (itemCategory if (!countsByItemID.has(item.id) || countsByItemID[item.id] <= 1) else (itemCategory + [str(countsByItemID[item.id])+"x"+item.getVisibleName()]))})
 			else:
 				#canActuallyPutOn += 1
 				addStartAction(["npc", item.id], "", "", theActivityScore*item.getAIForceItemWeight(dom, sub))

--- a/Game/SexEngine/SexActivity/DomDrugUse.gd
+++ b/Game/SexEngine/SexActivity/DomDrugUse.gd
@@ -115,13 +115,14 @@ func addDrugButtons(possibleDrugsInfo:Array, _sexEngine: SexEngine, _domInfo: Se
 		else:
 			drugFetishScore = clamp(_domInfo.fetishScore({Fetish.DrugUse: 1.0}) + 0.5, 0.0, 1.0) / 10.0
 
+		var drugSubcategory:Array = item.getSexEngineSubcategory() if(item != null) else []
 		if((_isCanApply || !dom.isOralBlocked()) && (!drugInfo.has("canUseOnDom") || drugInfo["canUseOnDom"])):
-			addStartAction(["useonself", itemID, _isCanApply, item], drugInfo["name"], desc, drugInfo["scoreOnSelf"] * drugFetishScore, {A_CATEGORY: getCategory()+["Self" if !_isCanApply else "Apply self"]})
+			addStartAction(["useonself", itemID, _isCanApply, item], drugInfo["name"], desc, drugInfo["scoreOnSelf"] * drugFetishScore, {A_CATEGORY: getCategory()+["Self" if !_isCanApply else "Apply self"]+drugSubcategory})
 		if((_isCanApply || !sub.isOralBlocked()) && (!drugInfo.has("canUseOnSub") || drugInfo["canUseOnSub"])):
 			if(_subInfo.canDoActions() && _sexEngine.getSexTypeID() != SexType.SlutwallSex && !_isCanApply):
-				addStartAction(["offertosub", itemID, _isCanApply, item], drugInfo["name"], desc, drugInfo["scoreOnSub"]*(1.0 - _domInfo.getAngerScore()) * drugFetishScore, {A_CATEGORY: getCategory()+["Offer to sub"]})
+				addStartAction(["offertosub", itemID, _isCanApply, item], drugInfo["name"], desc, drugInfo["scoreOnSub"]*(1.0 - _domInfo.getAngerScore()) * drugFetishScore, {A_CATEGORY: getCategory()+["Offer to sub"]+drugSubcategory})
 			
-			addStartAction(["forcetosub", itemID, _isCanApply, item], drugInfo["name"], desc, drugInfo["scoreOnSub"]*(_domInfo.getAngerScore() if !_isCanApply else 1.0) * drugFetishScore, {A_CATEGORY: getCategory()+["Force on sub" if !_isCanApply else "Apply on sub"]})
+			addStartAction(["forcetosub", itemID, _isCanApply, item], drugInfo["name"], desc, drugInfo["scoreOnSub"]*(_domInfo.getAngerScore() if !_isCanApply else 1.0) * drugFetishScore, {A_CATEGORY: getCategory()+["Force on sub" if !_isCanApply else "Apply on sub"]+drugSubcategory})
 
 func pcCanSeeText(ifcan, ifcant = "some pill"):
 	if(GM.pc.isBlindfolded()):

--- a/Inventory/ItemBase.gd
+++ b/Inventory/ItemBase.gd
@@ -683,6 +683,9 @@ func getInventoryGroupID() -> String:
 func getInventoryGroupName() -> String:
 	return getVisibleName()
 
+func getSexEngineSubcategory() -> Array:
+	return []
+
 func getDatapackEditVars():
 	var result = {}
 	if(canDye()):

--- a/Inventory/Items/TFPill.gd
+++ b/Inventory/Items/TFPill.gd
@@ -28,6 +28,9 @@ func getVisibleName():
 func getInventoryGroupName() -> String:
 	return "Transformation pills"
 
+func getSexEngineSubcategory() -> Array:
+	return ["TF pills"]
+
 func getDescription():
 	var theDesc:String = "A pill that lacks any labels or instructions. Who knows what it will do..\n"
 	if(tfID == "" || !GM.main.SCI.isTransformationUnlocked(tfID)):


### PR DESCRIPTION
<img width="728" height="137" alt="Actions panel, with transformation pills separated away into a subcategory" src="https://github.com/user-attachments/assets/1eafe2d7-064a-4d17-b333-a4dd7f92a91d" />

gives tf pills their own group, so you can find painkillers, heat pills etc. more easily

while it could be a design choice to force the player to use the stash more often, the player could probably keep TF pills in a separate container.. even with this PR it can take quite a bit of time to find the correct TF pill

* * *

bondage items get the same functionality, so if a modder wanted to group highly similar bdsm items into one subcategory, they could..