### PR TITLE
search & mod order drag n drop

### DIFF
--- a/UI/LaunchScreen/LaunchModEntry.gd
+++ b/UI/LaunchScreen/LaunchModEntry.gd
@@ -11,14 +11,16 @@ signal onSelected(modEntry)
 func setMyIdx(nv):
 	myidx = nv
 	var col = Color.white
+	var dis = false
 	if storedEntry:
-		label.text = str(nv+1) + ": "+storedEntry["name"] + (" (disabled)" if storedEntry.get("disabled",false) else "")
+		dis = storedEntry.get("disabled",false)
+		label.text = str(nv+1) + ": "+storedEntry["name"] + (" (disabled)" if dis else "")
 		if storedEntry.get("broken",false):
 			col = Color.red
 			label.text = "(BROKEN) "+label.text
 	else:
 		label.text = str(nv+1)+" NO ENTRY!!!!"
-	label["custom_colors/font_color"] = col
+	label.add_color_override("font_color",col.darkened(int(dis)*0.3))
 
 func setModEntry(modEntry,idx=-100):
 	storedEntry = modEntry
@@ -41,7 +43,7 @@ func _notification(what):
 		drop_data(rect_position,get_viewport().gui_get_drag_data())
 
 func get_drag_data(_position):
-	if !storedEntry:
+	if !storedEntry or !Rect2(Vector2.ZERO,rect_size).has_point(_position) or get_viewport().gui_get_drag_data():
 		return
 	var data = {"entry":storedEntry,"origin":self}
 	set_drag_preview(getPreview())
@@ -49,10 +51,15 @@ func get_drag_data(_position):
 
 func getPreview():
 	var lp = Control.new()
+	var panel = PanelContainer.new()
 	var l = Label.new()
 	l.text = label.text
-	lp.rect_min_size = Vector2(150,20)
-	lp.add_child(l)
+	lp.rect_min_size = rect_size
+	panel.size_flags_horizontal = panel.SIZE_EXPAND_FILL
+	panel.size_flags_vertical = panel.SIZE_EXPAND_FILL
+	lp.add_child(panel)
+	l.add_color_override("font_color",label.get_color("font_color"))
+	panel.add_child(l)
 	return lp
 
 func drop_data(_position, data):
@@ -70,6 +77,4 @@ func drop_data(_position, data):
 	emit_signal("weMoved",[newidx,neworiginidx])
 
 func can_drop_data(_position, data):
-	if typeof(data)!=TYPE_DICTIONARY:
-		return false
-	return true
+	return typeof(data)==TYPE_DICTIONARY

--- a/UI/LaunchScreen/LaunchModEntry.gd
+++ b/UI/LaunchScreen/LaunchModEntry.gd
@@ -3,26 +3,27 @@ extends PanelContainer
 onready var label:Label = $HBoxContainer/Label
 
 var storedEntry = null
-var myidx = -100
+var myidx = -100 setget setMyIdx
 
 signal weMoved(ar)
 signal onSelected(modEntry)
 
-func setModEntry(modEntry,idx=-100):
-	if idx>=0:
-		myidx = idx
-	label.text = (str(myidx+1)+": " if myidx>=0 else "?")+modEntry["name"]
-	if(modEntry["disabled"]):
-		label.text += " (disabled)"
-	if(modEntry.has("broken") && modEntry["broken"]):
-		label.text = "(BROKEN) "+label.text
-		label["custom_colors/font_color"] = Color.red
-		
-	storedEntry = modEntry
+func setMyIdx(nv):
+	myidx = nv
+	var col = Color.white
+	if storedEntry:
+		label.text = str(nv+1) + ": "+storedEntry["name"] + (" (disabled)" if storedEntry.get("disabled",false) else "")
+		if storedEntry.get("broken",false):
+			col = Color.red
+			label.text = "(BROKEN) "+label.text
+	else:
+		label.text = str(nv+1)+" NO ENTRY!!!!"
+	label["custom_colors/font_color"] = col
 
-func updIdx(change:int=-100):
-	myidx+=change
-	label.text = str(myidx+1)+": "+(storedEntry["name"] if storedEntry else "NO ENTRY!!!!")
+func setModEntry(modEntry,idx=-100):
+	storedEntry = modEntry
+	if idx>=0:
+		self.myidx = idx # to call setter
 
 func _on_TextureButton_pressed():
 	emit_signal("onSelected", storedEntry)

--- a/UI/LaunchScreen/LaunchModEntry.gd
+++ b/UI/LaunchScreen/LaunchModEntry.gd
@@ -3,11 +3,15 @@ extends PanelContainer
 onready var label:Label = $HBoxContainer/Label
 
 var storedEntry = null
+var myidx = -100
 
+signal weMoved(ar)
 signal onSelected(modEntry)
 
-func setModEntry(modEntry):
-	label.text = modEntry["name"]
+func setModEntry(modEntry,idx=-100):
+	if idx>=0:
+		myidx = idx
+	label.text = (str(myidx+1)+": " if myidx>=0 else "?")+modEntry["name"]
 	if(modEntry["disabled"]):
 		label.text += " (disabled)"
 	if(modEntry.has("broken") && modEntry["broken"]):
@@ -16,6 +20,9 @@ func setModEntry(modEntry):
 		
 	storedEntry = modEntry
 
+func updIdx(change:int=-100):
+	myidx+=change
+	label.text = str(myidx+1)+": "+(storedEntry["name"] if storedEntry else "NO ENTRY!!!!")
 
 func _on_TextureButton_pressed():
 	emit_signal("onSelected", storedEntry)
@@ -25,3 +32,43 @@ func makeActive():
 
 func makeInactive():
 	$Panel.visible = false
+
+func _notification(what):
+	if what==NOTIFICATION_DRAG_BEGIN:
+		get_drag_data(rect_position)
+	elif what==NOTIFICATION_DRAG_END:
+		drop_data(rect_position,get_viewport().gui_get_drag_data())
+
+func get_drag_data(_position):
+	if !storedEntry:
+		return
+	var data = {"entry":storedEntry,"origin":self}
+	set_drag_preview(getPreview())
+	return data
+
+func getPreview():
+	var lp = Control.new()
+	var l = Label.new()
+	l.text = label.text
+	lp.rect_min_size = Vector2(150,20)
+	lp.add_child(l)
+	return lp
+
+func drop_data(_position, data):
+	if typeof(data)!=TYPE_DICTIONARY:
+		return
+	var origin = data.get("origin",null)
+	if !origin:
+		return
+	if origin==self or origin.myidx==myidx:
+		return
+	var newidx = origin.myidx
+	var neworiginidx = myidx
+	origin.setModEntry(storedEntry,neworiginidx)
+	setModEntry(data["entry"],newidx)
+	emit_signal("weMoved",[newidx,neworiginidx])
+
+func can_drop_data(_position, data):
+	if typeof(data)!=TYPE_DICTIONARY:
+		return false
+	return true

--- a/UI/LaunchScreen/LaunchModEntry.tscn
+++ b/UI/LaunchScreen/LaunchModEntry.tscn
@@ -16,6 +16,7 @@ script = ExtResource( 1 )
 visible = false
 margin_right = 1280.0
 margin_bottom = 720.0
+mouse_filter = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 margin_right = 1280.0
@@ -25,6 +26,7 @@ margin_bottom = 720.0
 margin_top = 353.0
 margin_right = 1280.0
 margin_bottom = 367.0
+mouse_filter = 1
 size_flags_horizontal = 3
 text = "Test mod"
 autowrap = true
@@ -32,6 +34,7 @@ autowrap = true
 [node name="TextureButton" type="TextureButton" parent="."]
 margin_right = 1280.0
 margin_bottom = 720.0
+mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
 

--- a/UI/LaunchScreen/LaunchScreen.gd
+++ b/UI/LaunchScreen/LaunchScreen.gd
@@ -4,6 +4,9 @@ onready var modDescriptionLabel = $VBoxContainer/HBoxContainer/VBoxContainer/Pan
 onready var modVList = $VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/ScrollContainer/ModList
 onready var modFileList = $VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer2/VBoxContainer/ModFileList
 onready var modDisableButton = $VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer2/VBoxContainer/HFlowContainer/ModDisableButton
+onready var searchBar = $VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/orderhb/search
+onready var modCountLabel = $VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/orderhb/Label
+
 onready var debug_button = $"%DebugButton"
 onready var building_pck_panel = $"%BuildingPCKPanel"
 
@@ -151,15 +154,33 @@ func loadOrderFromFile():
 
 func updateModList():
 	Util.delete_children(modVList)
-	
-	for modEntry in currentModOrder:
+	var modsCount = currentModOrder.size()
+	modCountLabel.text = "Mod order"+(" ("+str(modsCount)+")" if modsCount else "")
+	for modEntryIdx in modsCount: # need the idx, save processing power (hopefully?)
+		var modEntry = currentModOrder[modEntryIdx]
 		var newEntry = launchModEntryScene.instance()
 		modVList.add_child(newEntry)
-		newEntry.setModEntry(modEntry)
+		newEntry.setModEntry(modEntry,modEntryIdx)
 		newEntry.connect("onSelected", self, "onModEntryClicked")
+		newEntry.connect("weMoved",self,"modEntryDroppedData")
+#		newEntry.connect("mouse_exited",self,"_onModEntryNodeGuiEvent",[newEntry])
 		
 		if(modEntry == selectedEntry):
 			newEntry.makeActive()
+	
+	showSearched()
+
+func modEntryDroppedData(ar:Array=[]):
+	if ar.size()!=2:
+		return
+	ar.sort()
+	var entry1 = currentModOrder.pop_at(ar[1])
+	var entry2 = currentModOrder.pop_at(ar[0])
+	
+	currentModOrder.insert(ar[0],entry1)
+	currentModOrder.insert(ar[1],entry2)
+	saveOrderIntoFile(currentModOrder)
+	updateModList()
 
 func _on_WithModsButton_pressed():
 	if(startedPlaying):
@@ -296,7 +317,16 @@ func _on_MoveUpButton_pressed():
 	currentModOrder.insert(newIndex, selectedEntry)
 	
 	ensureBDCCIsFirst()
-	updateModList()
+#	updateModList()
+	var modNodeC = modVList.get_child_count()
+	if modNodeC<currentIndex:
+		return
+	var node = modVList.get_child(currentIndex)
+	if node:
+		modVList.move_child(node,newIndex)
+		node.updIdx(-1)
+	var otherNode = modVList.get_child(currentIndex)
+	otherNode.updIdx(+1)
 
 
 func _on_MoveDownButton_pressed():
@@ -310,7 +340,16 @@ func _on_MoveDownButton_pressed():
 	currentModOrder.remove(currentIndex)
 	currentModOrder.insert(newIndex, selectedEntry)
 	
-	updateModList()
+#	updateModList()
+	var modNodeC = modVList.get_child_count()
+	if modNodeC<currentIndex:
+		return
+	var node = modVList.get_child(currentIndex)
+	if node:
+		modVList.move_child(node,newIndex)
+		node.updIdx(+1)
+	var otherNode = modVList.get_child(currentIndex)
+	otherNode.updIdx(-1)
 
 func ensureBDCCIsFirst():
 	for _i in range(currentModOrder.size()):
@@ -580,3 +619,50 @@ func _on_HTTPRequestMods_request_completed(_result: int, _response_code: int, _h
 		updateModList()
 		updateSelectedEntry()
 	
+
+func getNodeWithEntry(modEntry={}):
+	for launchModEntry in modVList.get_children():
+		if launchModEntry.get("storedEntry")==modEntry:
+			return launchModEntry
+	return null
+
+func sortModEntryNodes():
+#	var modNodesCount = modVList.get_child_count()
+	var orderSize = currentModOrder.size()
+	for idx in orderSize:
+		var entry = currentModOrder[idx]
+		var node = getNodeWithEntry(entry)
+		if !node: # doesn't exist? make it
+			var newEntry = launchModEntryScene.instance()
+			modVList.add_child(newEntry)
+			newEntry.setModEntry(entry,idx)
+			newEntry.connect("onSelected", self, "onModEntryClicked")
+			
+			if(entry == selectedEntry):
+				newEntry.makeActive()
+			continue
+		
+		# exists, sort
+		modVList.move_child(node,idx)
+		
+	
+
+func _on_search_text_changed(new_text:String):
+	showSearched(new_text)
+
+func showSearched(searchQuery=searchBar.text):
+	var selIdx = -100 # other idxs can never be negative
+	if selectedEntry:
+		selIdx = currentModOrder.find(selectedEntry)
+	for nodeIdx in modVList.get_child_count():
+		var node = modVList.get_child(nodeIdx)
+		var stentry = node.get("storedEntry")
+		if !searchQuery.strip_edges():
+			node.show()
+			continue
+		if !stentry:
+			node.hide()
+			continue
+		var stext : String = searchQuery.to_lower()
+		var entryname = stentry.get("name","").to_lower()
+		node.visible = stext in entryname or stext.similarity(entryname)>=0.75 or entryname.begins_with(stext) or (abs(selIdx-nodeIdx)<2)

--- a/UI/LaunchScreen/LaunchScreen.gd
+++ b/UI/LaunchScreen/LaunchScreen.gd
@@ -163,7 +163,6 @@ func updateModList():
 		newEntry.setModEntry(modEntry,modEntryIdx)
 		newEntry.connect("onSelected", self, "onModEntryClicked")
 		newEntry.connect("weMoved",self,"modEntryDroppedData")
-#		newEntry.connect("mouse_exited",self,"_onModEntryNodeGuiEvent",[newEntry])
 		
 		if(modEntry == selectedEntry):
 			newEntry.makeActive()
@@ -180,7 +179,10 @@ func modEntryDroppedData(ar:Array=[]):
 	currentModOrder.insert(ar[0],entry1)
 	currentModOrder.insert(ar[1],entry2)
 	saveOrderIntoFile(currentModOrder)
-	updateModList()
+	
+	# visual
+	modVList.get_child(ar[0]).myidx = ar[0]
+	modVList.get_child(ar[1]).myidx = ar[1]
 
 func _on_WithModsButton_pressed():
 	if(startedPlaying):
@@ -317,16 +319,16 @@ func _on_MoveUpButton_pressed():
 	currentModOrder.insert(newIndex, selectedEntry)
 	
 	ensureBDCCIsFirst()
-#	updateModList()
+	
 	var modNodeC = modVList.get_child_count()
 	if modNodeC<currentIndex:
 		return
 	var node = modVList.get_child(currentIndex)
 	if node:
 		modVList.move_child(node,newIndex)
-		node.updIdx(-1)
+		node.myidx = newIndex
 	var otherNode = modVList.get_child(currentIndex)
-	otherNode.updIdx(+1)
+	otherNode.myidx = currentIndex
 
 
 func _on_MoveDownButton_pressed():
@@ -340,16 +342,16 @@ func _on_MoveDownButton_pressed():
 	currentModOrder.remove(currentIndex)
 	currentModOrder.insert(newIndex, selectedEntry)
 	
-#	updateModList()
+	
 	var modNodeC = modVList.get_child_count()
 	if modNodeC<currentIndex:
 		return
 	var node = modVList.get_child(currentIndex)
 	if node:
 		modVList.move_child(node,newIndex)
-		node.updIdx(+1)
+		node.myidx = newIndex
 	var otherNode = modVList.get_child(currentIndex)
-	otherNode.updIdx(-1)
+	otherNode.myidx = currentIndex
 
 func ensureBDCCIsFirst():
 	for _i in range(currentModOrder.size()):
@@ -627,7 +629,6 @@ func getNodeWithEntry(modEntry={}):
 	return null
 
 func sortModEntryNodes():
-#	var modNodesCount = modVList.get_child_count()
 	var orderSize = currentModOrder.size()
 	for idx in orderSize:
 		var entry = currentModOrder[idx]

--- a/UI/LaunchScreen/LaunchScreen.tscn
+++ b/UI/LaunchScreen/LaunchScreen.tscn
@@ -80,14 +80,28 @@ margin_bottom = 661.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
+[node name="orderhb" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
 margin_right = 411.0
-margin_bottom = 20.0
+margin_bottom = 30.0
+custom_constants/separation = 12
+alignment = 1
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/orderhb"]
+margin_top = 5.0
+margin_right = 89.0
+margin_bottom = 25.0
 text = "Mod order"
 align = 1
 
+[node name="search" type="LineEdit" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/orderhb"]
+margin_left = 101.0
+margin_right = 411.0
+margin_bottom = 30.0
+size_flags_horizontal = 3
+placeholder_text = "Search..."
+
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer"]
-margin_top = 24.0
+margin_top = 34.0
 margin_right = 411.0
 margin_bottom = 654.0
 size_flags_horizontal = 3
@@ -96,7 +110,7 @@ script = ExtResource( 3 )
 
 [node name="ModList" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/ScrollContainer"]
 margin_right = 411.0
-margin_bottom = 630.0
+margin_bottom = 620.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -316,6 +330,7 @@ unique_name_in_owner = true
 
 [connection signal="pressed" from="VBoxContainer/Label/DebugButton" to="." method="_on_DebugButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/Label/CheckBrokenModsButton" to="." method="_on_CheckBrokenModsButton_pressed"]
+[connection signal="text_changed" from="VBoxContainer/HBoxContainer/PanelContainer/VBoxContainer/orderhb/search" to="." method="_on_search_text_changed"]
 [connection signal="meta_clicked" from="VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer2/VBoxContainer/WarningLabel" to="." method="_on_RichTextLabel_meta_clicked"]
 [connection signal="meta_clicked" from="VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer2/VBoxContainer/RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer2/VBoxContainer/HFlowContainer/ModDisableButton" to="." method="_on_ModDisableButton_pressed"]


### PR DESCRIPTION
- added a search function for the mod launcher, which shows mods with a similar name to the search query, as well as the two neighboring mods of the selected mod
- mods now show their position in the mod order, useful?
- you can now drag and drop mods around your mod order, and the order is saved when you release the mouse button
- also the mod order now shows how many mods you have next to the search bar thing

(...it was indeed annoying :/)