### PR TITLE
Make room transitions form after WorldEdits are applied

### DIFF
--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -252,6 +252,7 @@ func _ready():
 	Console.addCommand("become", self, "consoleBecome", ["charID"], "Become another character")
 	#Console.addCommand("ae", self, "consoleAnimationEditor", [], "Animation editor")
 	applyAllWorldEdits()
+	GM.world.addTransitions()
 	
 func startNewGame():
 	GlobalRegistry.currentSave = 1
@@ -422,6 +423,7 @@ func loadingSavefileFinished():
 	reRun()
 	
 	applyAllWorldEdits()
+	GM.world.addTransitions()
 	
 	if(!rollbacker.rollbacking):
 		WHS.clearHistory()

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -251,8 +251,6 @@ func _ready():
 	Console.addCommand("clearmoduleflag", self, "consoleClearModuleFlag", ["moduleID", "flagID"], "Resets the game flag, be very careful")
 	Console.addCommand("become", self, "consoleBecome", ["charID"], "Become another character")
 	#Console.addCommand("ae", self, "consoleAnimationEditor", [], "Animation editor")
-	applyAllWorldEdits()
-	GM.world.addTransitions()
 	
 func startNewGame():
 	GlobalRegistry.currentSave = 1

--- a/Game/World/World.gd
+++ b/Game/World/World.gd
@@ -175,7 +175,7 @@ func addTransitions(floorIDs:Array = []):
 	if(floorIDs.empty()):
 		floorIDs = cells.keys()
 	
-	for floorid in cells:
+	for floorid in floorIDs:
 		var floorcells = cells[floorid]
 		for pos in floorcells:
 			var _room = floorcells[pos]

--- a/Game/World/World.gd
+++ b/Game/World/World.gd
@@ -248,7 +248,6 @@ func _ready():
 				
 				registerRoom(f.id, cell)
 	
-	addTransitions()
 	#print(roomDict)
 	#aimCamera("ScriptedRoom")#"cellblock_orange_playercell")
 


### PR DESCRIPTION
Currently when you add rooms with a `WorldEdit`, it doesn't add transition lines. You can fix this manually but it kind of sucks that you have to. It can be better.

This changes the game so that world edits are applied and _then_ transitions are added. Now world edit rooms have lines.

Bonus: While I was exploring this, I noticed that transitions were added twice, and also the filter for flood IDs wasn't working so the game was adding transitions for the entire game every time a drug den floor was generated. I fixed this. Now lines should only be added once.

Won't help with dynamically added rooms but there's only so much you can do.