### PR TITLE
Preserve camera and location when in rooms added by WorldEdits

### DIFF
--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -423,7 +423,7 @@ func loadingSavefileFinished():
 	applyAllWorldEdits()
 	GM.world.addTransitions()
 	GM.world.resetCamera()
-	GM.pc.checkLocation()
+	GM.pc.checkLocation(true)
 	
 	if(!rollbacker.rollbacking):
 		WHS.clearHistory()

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -422,6 +422,8 @@ func loadingSavefileFinished():
 	
 	applyAllWorldEdits()
 	GM.world.addTransitions()
+	GM.world.resetCamera()
+	GM.pc.checkLocation()
 	
 	if(!rollbacker.rollbacking):
 		WHS.clearHistory()
@@ -602,8 +604,6 @@ func loadData(data):
 	GM.world.loadData(SAVE.loadVar(data, "world", {}))
 	#GM.world.updatePawns(IS)
 	#GM.world.setPawnsShowed(canShowPawns())
-
-	GM.pc.checkLocation()
 
 func saveCharactersData():
 	var data = {}

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -422,8 +422,8 @@ func loadingSavefileFinished():
 	
 	applyAllWorldEdits()
 	GM.world.addTransitions()
-	GM.world.resetCamera()
-	GM.pc.checkLocation(true)
+	GM.world.resetCamera(true)
+	GM.pc.checkLocation()
 	
 	if(!rollbacker.rollbacking):
 		WHS.clearHistory()
@@ -555,7 +555,6 @@ func loadData(data):
 	SCI.loadData(SAVE.loadVar(data, "science", {}))
 	PSH.loadData(SAVE.loadVar(data, "playerSlaveryHolder", {}))
 		
-	
 	var scenes = SAVE.loadVar(data, "scenes", [])
 	
 	for scene in sceneStack:

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -422,8 +422,8 @@ func loadingSavefileFinished():
 	
 	applyAllWorldEdits()
 	GM.world.addTransitions()
-	GM.world.resetCamera(true)
 	GM.pc.checkLocation()
+	GM.world.aimCamera(GM.pc.location, true)
 	
 	if(!rollbacker.rollbacking):
 		WHS.clearHistory()

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -566,6 +566,8 @@ func loadData(data):
 		var id = SAVE.loadVar(sceneData, "id", "error")
 		
 		var scene = GlobalRegistry.createScene(id)
+		if(scene == null):
+			break
 		add_child(scene)
 		sceneStack.append(scene)
 		print("Starting scene "+id)

--- a/Game/World/World.gd
+++ b/Game/World/World.gd
@@ -339,6 +339,10 @@ func aimCamera(roomID, instantly = false):
 	if(instantly):
 		camera.reset_smoothing()
 
+func resetCamera(instant:bool = false):
+	if(lastAimedRoomID != null && lastAimedRoomID != ""):
+		aimCamera(lastAimedRoomID, instant)
+
 func zoomIn(mult:float = 1.0):
 	camera.zoom *= 1.1 * mult
 	updateDarknessSize()
@@ -752,5 +756,3 @@ func loadData(data):
 		camera.zoom = Vector2(SAVE.loadVar(data, "zoomx", 1.0), SAVE.loadVar(data, "zoomy", 1.0))
 	
 	updateDarknessSize()
-	if(lastAimedRoomID != null && lastAimedRoomID != ""):
-		aimCamera(lastAimedRoomID, true)

--- a/Game/World/World.gd
+++ b/Game/World/World.gd
@@ -339,10 +339,6 @@ func aimCamera(roomID, instantly = false):
 	if(instantly):
 		camera.reset_smoothing()
 
-func resetCamera(instant:bool = false):
-	if(lastAimedRoomID != null && lastAimedRoomID != ""):
-		aimCamera(lastAimedRoomID, instant)
-
 func zoomIn(mult:float = 1.0):
 	camera.zoom *= 1.1 * mult
 	updateDarknessSize()
@@ -756,3 +752,5 @@ func loadData(data):
 		camera.zoom = Vector2(SAVE.loadVar(data, "zoomx", 1.0), SAVE.loadVar(data, "zoomy", 1.0))
 	
 	updateDarknessSize()
+	if(lastAimedRoomID != null && lastAimedRoomID != ""):
+		aimCamera(lastAimedRoomID, true)


### PR DESCRIPTION
When a room is added with a World Edit, the player's location is checked before the World Edit is applied so they're always reset to their cell.

Similarly, if they are in a Scene, this happens with the last camera location. You end up with some funky stuff if you load into a room added by a World Edit inside a Scene:
<img width="244" height="197" alt="image" src="https://github.com/user-attachments/assets/96f53125-35e9-47ce-a1fc-0d289930b25a" />
<img width="252" height="204" alt="image" src="https://github.com/user-attachments/assets/5fff4842-0226-40e8-906c-6d2eae266fc6" />

This fixes this by just moving the check for PC location and setting the camera to after World Edits are applied.