### PR TITLE
Make it so location saves correctly for rooms added by World Edits

### DIFF
--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -283,6 +283,7 @@ func getNewUniqueSceneID(blockedIDS=[]) -> int:
 	return result
 
 func runScene(id, _args = [], parentSceneUniqueID = -1):
+	GM.world.set("lastAimedRoomID", GM.pc.getLocation())
 	var scene = GlobalRegistry.createScene(id)
 	assert(scene != null, "SCENE WITH ID "+str(id)+" IS NOT FOUND. MAKE SURE IT WAS REGISTERED INSIDE THE MODULE.")
 	scene.uniqueSceneID = getNewUniqueSceneID([parentSceneUniqueID])
@@ -606,6 +607,9 @@ func loadData(data):
 	applyAllWorldEdits()
 	GM.world.addTransitions()
 	GM.pc.checkLocation()
+	var lastAimedLocation = GM.world.get("lastAimedRoomID")
+	if(lastAimedLocation != null && lastAimedLocation != ""):
+		GM.world.aimCamera(lastAimedLocation, true)
 
 func saveCharactersData():
 	var data = {}

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -565,6 +565,9 @@ func loadData(data):
 		var id = SAVE.loadVar(sceneData, "id", "error")
 		
 		var scene = GlobalRegistry.createScene(id)
+		if(scene == null):
+			# If a scene doesn't exist, abort so the game is at least playable
+			break
 		add_child(scene)
 		sceneStack.append(scene)
 		print("Starting scene "+id)

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -420,9 +420,6 @@ func loadingSavefileFinished():
 	#	GM.ui.getStage3d().resetToNothing()
 	reRun()
 	
-	applyAllWorldEdits()
-	GM.world.addTransitions()
-	
 	if(!rollbacker.rollbacking):
 		WHS.clearHistory()
 	IS.updatePCLocation()
@@ -606,6 +603,8 @@ func loadData(data):
 	#GM.world.updatePawns(IS)
 	#GM.world.setPawnsShowed(canShowPawns())
 
+	applyAllWorldEdits()
+	GM.world.addTransitions()
 	GM.pc.checkLocation()
 
 func saveCharactersData():

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -283,7 +283,7 @@ func getNewUniqueSceneID(blockedIDS=[]) -> int:
 	return result
 
 func runScene(id, _args = [], parentSceneUniqueID = -1):
-	GM.world.set("lastAimedRoomID", GM.pc.getLocation())
+	GM.world.lastAimedRoomID = GM.pc.getLocation()
 	var scene = GlobalRegistry.createScene(id)
 	assert(scene != null, "SCENE WITH ID "+str(id)+" IS NOT FOUND. MAKE SURE IT WAS REGISTERED INSIDE THE MODULE.")
 	scene.uniqueSceneID = getNewUniqueSceneID([parentSceneUniqueID])
@@ -604,7 +604,7 @@ func loadData(data):
 	applyAllWorldEdits()
 	GM.world.addTransitions()
 	GM.pc.checkLocation()
-	var lastAimedLocation = GM.world.get("lastAimedRoomID")
+	var lastAimedLocation = GM.world.lastAimedRoomID
 	if(lastAimedLocation != null && lastAimedLocation != ""):
 		GM.world.aimCamera(lastAimedLocation, true)
 

--- a/Game/MainScene.gd
+++ b/Game/MainScene.gd
@@ -563,9 +563,6 @@ func loadData(data):
 		var id = SAVE.loadVar(sceneData, "id", "error")
 		
 		var scene = GlobalRegistry.createScene(id)
-		if(scene == null):
-			# If a scene doesn't exist, abort so the game is at least playable
-			break
 		add_child(scene)
 		sceneStack.append(scene)
 		print("Starting scene "+id)

--- a/Game/World/World.gd
+++ b/Game/World/World.gd
@@ -752,5 +752,3 @@ func loadData(data):
 		camera.zoom = Vector2(SAVE.loadVar(data, "zoomx", 1.0), SAVE.loadVar(data, "zoomy", 1.0))
 	
 	updateDarknessSize()
-	if(lastAimedRoomID != null && lastAimedRoomID != ""):
-		aimCamera(lastAimedRoomID, true)


### PR DESCRIPTION
Let's try this one more time.

I noticed that saving in a room that was added by a World Edit always caused the player's location to get reset. Separately, I noticed that saving during a scene that happened to take place in an added room caused the camera to have a moment.

I have fixed these problems. The player's location is now checked after World Edits are applied, and the camera aim is saved at the start of scenes.

I also fixed a softlock that happens when loading a save that's in the middle of a scene that doesn't exist. It made testing this annoying.

<img width="244" height="197" alt="image" src="https://github.com/user-attachments/assets/0f32f231-69af-48d7-ad0b-b9d070711c15" />
<img width="252" height="204" alt="image" src="https://github.com/user-attachments/assets/bde43156-b111-4c4e-b630-d460f5f681fb" />
