### PR TITLE
no inappropriate item use in battle

### DIFF
--- a/Inventory/Items/PermanentMarker.gd
+++ b/Inventory/Items/PermanentMarker.gd
@@ -9,8 +9,8 @@ func getVisibleName():
 func getDescription():
 	return "A single-use marker that is loaded with special ink that is almost impossible to remove."
 
-#func canUseInCombat():
-#	return true
+func canUseInCombat():
+	return false
 #
 #func useInCombat(_attacker, _receiver):
 #	removeXOrDestroy(getAmount())

--- a/Scenes/InventoryScene.gd
+++ b/Scenes/InventoryScene.gd
@@ -227,6 +227,10 @@ func onInventoryItemSelected(item: ItemBase):
 		else:
 			addButton("Put on", item.getVisisbleDescription(), "puton", [item.getUniqueID()])
 	
+	if item.canUseInCombat()==false:
+		addDisabledButton("Can't use!","You can't use this item in combat")
+		return
+	
 	for action in item.getPossibleActions():
 		if(!canDoAction(action)):
 			addDisabledButton(action["name"], "(Can't do this now)\n\n"+action["description"])

--- a/Scenes/InventoryScene.gd
+++ b/Scenes/InventoryScene.gd
@@ -227,7 +227,7 @@ func onInventoryItemSelected(item: ItemBase):
 		else:
 			addButton("Put on", item.getVisisbleDescription(), "puton", [item.getUniqueID()])
 	
-	if item.canUseInCombat()==false:
+	if(!item.canUseInCombat()):
 		addDisabledButton("Can't use!","You can't use this item in combat")
 		return
 	

--- a/UI/Inventory/InventoryEntry.gd
+++ b/UI/Inventory/InventoryEntry.gd
@@ -99,7 +99,7 @@ func updateInfo():
 	
 	if(isFightMode):
 		var possibleActions = item.getPossibleActions()
-		if(possibleActions.size() == 1 && canDoAction(possibleActions[0])):
+		if(possibleActions.size() == 1 && canDoAction(possibleActions[0]) && item.canUseInCombat()):
 			showUseButton(true)
 		else:
 			showUseButton(false)


### PR DESCRIPTION
- items that return false in canUseInCombat() func will not be usable in battle

i changed the permanent marker to be unusable in combat mostly for testing (and because someone said that it's supposed to be unusable in combat, but idk), i can remove that if needed