### PR TITLE
mod launcher improvements (?) & a few minor changes

### DIFF
--- a/Game/Datapacks/UI/CrotchCode/CrotchBlockVisual.gd
+++ b/Game/Datapacks/UI/CrotchCode/CrotchBlockVisual.gd
@@ -201,12 +201,8 @@ func _on_PopupMenu_index_pressed(index):
 	if(index == 0):
 		doSelfdelete()
 
-var lastRightClick = 0
 func _on_CrotchBlock_gui_input(event):
 	if event is InputEventMouseButton:
-		if event.pressed and event.button_index == BUTTON_RIGHT:
-			if((Time.get_ticks_msec() - lastRightClick) < 400.0):
-				editor.onUserChangeMade()
-				doSelfdelete(true)
-			else:
-				lastRightClick = Time.get_ticks_msec()
+		if event.pressed && event.doubleclick && event.button_index == BUTTON_RIGHT:
+			editor.onUserChangeMade()
+			doSelfdelete(true)

--- a/Scenes/ComputerSimScene.gd
+++ b/Scenes/ComputerSimScene.gd
@@ -42,7 +42,7 @@ func _run():
 			addButtonAt(0, "SEND", "Send the command", "sendkeyboard")
 			addButtonAt(14, "COMMANDS", "Switch to the commands", "buttons")
 		
-		if(inputMode == "buttons"):
+		elif(inputMode == "buttons"):
 			saynn("> "+ getCurrentCommandString())
 			#for key in TextTransitionSettings.transitions:
 			#	TextTransitionSettings.transitions[key].fade_in()
@@ -62,7 +62,7 @@ func _run():
 			for command in words:
 				addButton(command, "Type this", "add", [command])
 			
-		if(inputMode == "numpad"):
+		elif(inputMode == "numpad"):
 			saynn("> "+getCurrentCommandString())
 			
 			addButtonAt(1, "7", "Type this", "addnumpad", ["7"])
@@ -88,7 +88,7 @@ func _run():
 
 		#addButton("Leave", "Job well done", "endthescene")
 
-	if(state == "finished"):
+	elif(state == "finished"):
 		if(computer.getLastCommand() != ""):
 			saynn("> "+computer.getLastCommand())
 		if(shouldPlayFancyAnimationForText):

--- a/UI/LaunchScreen/LaunchModEntry.gd
+++ b/UI/LaunchScreen/LaunchModEntry.gd
@@ -7,6 +7,7 @@ var entryIndex:int = -1
 
 signal onDragOntoAnotherEntry(ar)
 signal onSelected(modEntry)
+signal onDoubleClicked(modEntry)
 
 func setModEntry(modEntry):
 	storedEntry = modEntry
@@ -25,9 +26,6 @@ func updateEntry():
 		theTextColor = theTextColor.darkened(0.3)
 		
 	label["custom_colors/font_color"] = theTextColor
-
-func _on_TextureButton_pressed():
-	emit_signal("onSelected", storedEntry)
 
 func makeActive():
 	$Panel.visible = true
@@ -53,9 +51,9 @@ func getPreview():
 	var panel = PanelContainer.new()
 	var l = Label.new()
 	l.text = label.text
+	panel.add_stylebox_override("panel",preload("res://UI/LaunchScreen/LaunchModEntryPanel.tres"))
 	lp.rect_min_size = rect_size
-	panel.size_flags_horizontal = panel.SIZE_EXPAND_FILL
-	panel.size_flags_vertical = panel.SIZE_EXPAND_FILL
+	panel.rect_min_size = rect_size
 	lp.add_child(panel)
 	l.add_color_override("font_color",label.get_color("font_color"))
 	panel.add_child(l)
@@ -75,3 +73,15 @@ func drop_data(_position, data):
 
 func can_drop_data(_position, data):
 	return typeof(data)==TYPE_DICTIONARY
+
+
+func _on_LaunchModEntry_gui_input(event):
+	if(not event is InputEventMouseButton):
+		return
+	if(event.button_index != BUTTON_LEFT): # fix scrolling up/down causing a new entry to be selected
+		return
+	if(event.doubleclick):
+		emit_signal("onDoubleClicked", storedEntry)
+		return # avoid double select, mostly for performance reasons
+	if(event.pressed):
+		emit_signal("onSelected", storedEntry)

--- a/UI/LaunchScreen/LaunchModEntry.tscn
+++ b/UI/LaunchScreen/LaunchModEntry.tscn
@@ -1,15 +1,13 @@
 [gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://UI/LaunchScreen/LaunchModEntry.gd" type="Script" id=1]
-
-[sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 0.196078, 0.196078, 0.196078, 1 )
+[ext_resource path="res://UI/LaunchScreen/LaunchModEntryPanel.tres" type="StyleBox" id=2]
 
 [node name="LaunchModEntry" type="PanelContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 0, 50 )
-custom_styles/panel = SubResource( 1 )
+custom_styles/panel = ExtResource( 2 )
 script = ExtResource( 1 )
 
 [node name="Panel" type="Panel" parent="."]
@@ -31,11 +29,4 @@ size_flags_horizontal = 3
 text = "Test mod"
 autowrap = true
 
-[node name="TextureButton" type="TextureButton" parent="."]
-margin_right = 1280.0
-margin_bottom = 720.0
-mouse_filter = 1
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[connection signal="pressed" from="TextureButton" to="." method="_on_TextureButton_pressed"]
+[connection signal="gui_input" from="." to="." method="_on_LaunchModEntry_gui_input"]

--- a/UI/LaunchScreen/LaunchModEntryPanel.tres
+++ b/UI/LaunchScreen/LaunchModEntryPanel.tres
@@ -1,0 +1,4 @@
+[gd_resource type="StyleBoxFlat" format=2]
+
+[resource]
+bg_color = Color( 0.196078, 0.196078, 0.196078, 1 )

--- a/UI/LaunchScreen/LaunchScreen.gd
+++ b/UI/LaunchScreen/LaunchScreen.gd
@@ -176,6 +176,7 @@ func updateModList():
 		newEntry.entryIndex = modEntryIdx
 		newEntry.setModEntry(modEntry)
 		newEntry.connect("onSelected", self, "onModEntryClicked")
+		newEntry.connect("onDoubleClicked", self, "toggleModEntryDisabled")
 		newEntry.connect("onDragOntoAnotherEntry",self,"modEntryDroppedData")
 		launchModEntries.append(newEntry)
 	
@@ -312,14 +313,16 @@ func tryToPopulateFilesList():
 		modFileList.add_item("Couldn't load any files")
 	return "Failed to load info"
 
-
-func _on_ModDisableButton_pressed():
-	if(selectedEntry == null or selectedEntry["name"] == "BDCC.pck"):
+func toggleModEntryDisabled(entry:Dictionary=selectedEntry) -> void:
+	if(entry == null or entry["name"] == "BDCC.pck"):
 		return
 	
-	selectedEntry["disabled"] = !selectedEntry["disabled"]
+	entry["disabled"] = !entry["disabled"]
 	updateModList()
 	updateSelectedEntry()
+
+func _on_ModDisableButton_pressed():
+	toggleModEntryDisabled(selectedEntry)
 
 
 func _on_MoveUpButton_pressed():


### PR DESCRIPTION
- simplified CrotchBlockVisual gui input
- minor changes in ComputerSimScene to avoid redundant checks maybe
- launcher mod entries can now be toggled on and off by double clicking, for more intuitive control to accompany the new dragging mods around thing
- also removed the texturebutton from the launch mod entries to reduce node count, and replaced their functionality with a gui_input function instead, so it should be functionally the same
- also saved the launch mod entry's panel stylebox for use with creating drag previews, which should be much more consistent now. this will hopefully make it easier to sync style changes between the entry and its drag preview
- finally, made toggling mods its own function, and made it so that you can specify an entry other than the currently selected one (maybe useful for inverting mod selections altogether for some reason?)